### PR TITLE
fix(oas): escape path only once

### DIFF
--- a/convertoas3/oas3_testfiles/12-path-parameter-regex.expected.json
+++ b/convertoas3/oas3_testfiles/12-path-parameter-regex.expected.json
@@ -45,6 +45,23 @@
           ]
         },
         {
+          "id": "8438e81a-7724-53a2-9b5b-5bb400ac8531",
+          "methods": [
+            "POST"
+          ],
+          "name": "path-parameter-test_postbatchwithparams",
+          "paths": [
+            "~/batchs\\(Material='(?<material>[^#?/]+)',Batch='(?<batch>[^#?/]+)'\\)$"
+          ],
+          "plugins": [],
+          "regex_priority": 100,
+          "strip_path": false,
+          "tags": [
+            "OAS3_import",
+            "OAS3file_12-path-parameter-regex.yaml"
+          ]
+        },
+        {
           "id": "0da1f8dc-e918-5379-b3b0-ffc061ae1691",
           "methods": [
             "GET"

--- a/convertoas3/oas3_testfiles/12-path-parameter-regex.yaml
+++ b/convertoas3/oas3_testfiles/12-path-parameter-regex.yaml
@@ -53,3 +53,20 @@ paths:
         "200":
           description: An echo message.
       operationId: getBatchWithParams
+    post:
+      # test vaildating not escaping the path twice; we have 2 methods on 1 path
+      parameters:
+        - in: path
+          name: Material
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: Batch
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: An echo message.
+      operationId: postBatchWithParams


### PR DESCRIPTION
for each operation in the path, the path would be escaped again.